### PR TITLE
Fix loading problems when Gem is built on Windows

### DIFF
--- a/lib/redcloth.rb
+++ b/lib/redcloth.rb
@@ -10,6 +10,11 @@ begin
   conf = Object.const_get(defined?(RbConfig) ? :RbConfig : :Config)::CONFIG
   prefix = conf['arch'] =~ /mswin|mingw/ ? "#{conf['MAJOR']}.#{conf['MINOR']}/" : ''
   lib = "#{prefix}redcloth_scan"
+  begin 
+    require lib
+  rescue LoadError => e
+    lib = "redcloth_scan"
+  end
   require lib
 rescue LoadError => e
   e.message << %{\nCouldn't load #{lib}\nThe $LOAD_PATH was:\n#{$LOAD_PATH.join("\n")}}


### PR DESCRIPTION
On Windows, the loading code in redcloth.rb assumed that one is loading it from a 'fat binary' gem. Using standard windows Ruby versions from 2.4 forward, the gem can be compiled by the user.

This change first tries to require the library using the prefix (for fat gems). If that fails, it tries again to require without the prefix (for built gems).

Fixes #51 and #61.